### PR TITLE
Avoid unlink when using Abstract Socket Address.

### DIFF
--- a/src/sock.cpp
+++ b/src/sock.cpp
@@ -173,7 +173,9 @@ void SockUnix::setUnixAddr(sockaddr_un &addr, const std::string &str)
 void SockUnix::closeChild()
 {
     if(m_isInit) {
-        unlink(m_me.c_str());
+        if (m_me != "") {
+            unlink(m_me.c_str());
+        }
         m_isInit = false;
     }
 }


### PR DESCRIPTION
Using an Abstract Socket Address (so_name[0] = '\0') we needn't to unlink the file before bind and after close.