### PR TITLE
Update m_actionField on message parse() call

### DIFF
--- a/src/msg.cpp
+++ b/src/msg.cpp
@@ -413,6 +413,7 @@ MNG_PARSE_ERROR_e Message::parse(const void *buf, ssize_t msgSize)
     if(actionField != RESPONSE && actionField != ACKNOWLEDGE &&
         actionField != COMMAND)
         return MNG_PARSE_ERROR_ACTION;
+    m_actionField = (actionField_e)(actionField);
     uint16_t *cur = (uint16_t *)(msg + 1);
     uint16_t tlvType = net_to_cpu16(*cur++);
     m_mngType = (tlvType_e)tlvType;


### PR DESCRIPTION
Hi Erez,

I noticed that calling parse() the m_actionField is not update. I don't know if this is a your choice or just a missing line of code.

Kindly, can you check this?
ciao

luigi