### PR TITLE
rpm: external package librtpi.spec improvement

### DIFF
--- a/rpm/external/librtpi.spec
+++ b/rpm/external/librtpi.spec
@@ -66,6 +66,8 @@ autoreconf --install
 %install
 %make_install
 
+find %{buildroot} -name "*.la" -delete
+
 %files -n %{name}1
 %{_libdir}/%{name}.so.*
 


### PR DESCRIPTION
Remove libtool generated /usr/lib64/librtpi.la in case of rpmbuild error: Installed (but unpackaged) file(s) found.
.la file is not need in modern linux distributions.